### PR TITLE
Allow for customization of member_data namespace

### DIFF
--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -26,7 +26,8 @@
       'memberKey': 'member',
       'rankKey': 'rank',
       'scoreKey': 'score',
-      'memberDataKey': 'member_data'
+      'memberDataKey': 'member_data',
+      'memberDataNamespace': 'member_data'
     };
 
     /*
@@ -80,6 +81,7 @@
       this.rankKeyOption = options['rankKey'] || 'rank';
       this.scoreKeyOption = options['scoreKey'] || 'score';
       this.memberDataKeyOption = options['memberDataKey'] || 'member_data';
+      this.memberDataNamespace = options['memberDataNamespace'] || 'member_data';
       this.redisConnection = redisOptions['redis_connection'];
       if (this.redisConnection != null) {
         delete redisOptions['redis_connection'];
@@ -1517,7 +1519,7 @@
 
 
     Leaderboard.prototype.memberDataKey = function(leaderboardName) {
-      return "" + leaderboardName + ":member_data";
+      return "" + leaderboardName + ":" + this.memberDataNamespace;
     };
 
     return Leaderboard;

--- a/spec/leaderboard_spec.coffee
+++ b/spec/leaderboard_spec.coffee
@@ -50,6 +50,20 @@ describe 'Leaderboard', ->
       reply[0]['member_data_custom'].should.equal('member_data_25')
       done())
 
+  it 'should allow you to change the memberDataNamespace option', (done) ->
+    updated_options =
+      'memberDataNamespace': 'md'
+
+    @leaderboard = new Leaderboard('highscores', updated_options)
+    for index in [0...Leaderboard.DEFAULT_PAGE_SIZE + 1]
+      @leaderboard.rankMember("member_#{index}", index, "member_data_#{index}", (reply) -> )
+
+    @leaderboard.redisConnection.exists('highscores:member_data', (err, reply) ->
+      reply.should.equal(0))
+    @leaderboard.redisConnection.exists('highscores:md', (err, reply) ->
+      reply.should.equal(1)
+      done())
+
   it 'should allow you to disconnect the Redis connection', (done) ->
     @leaderboard.disconnect()
     done()

--- a/src/leaderboard.coffee
+++ b/src/leaderboard.coffee
@@ -18,6 +18,7 @@ class Leaderboard
     'rankKey': 'rank'
     'scoreKey': 'score'
     'memberDataKey': 'member_data'
+    'memberDataNamespace': 'member_data'
 
   ###
   # Default Redis host: localhost
@@ -53,6 +54,7 @@ class Leaderboard
     @rankKeyOption = options['rankKey'] || 'rank'
     @scoreKeyOption = options['scoreKey'] || 'score'
     @memberDataKeyOption = options['memberDataKey'] || 'member_data'
+    @memberDataNamespace = options['memberDataNamespace'] || 'member_data'
 
     @redisConnection = redisOptions['redis_connection']
 
@@ -1072,6 +1074,6 @@ class Leaderboard
   # @return a key in the form of +leaderboardName:member_data+
   ###
   memberDataKey: (leaderboardName) ->
-    "#{leaderboardName}:member_data"
+    "#{leaderboardName}:#{@memberDataNamespace}"
 
 module.exports = Leaderboard


### PR DESCRIPTION
You can now pass in the `'memberDataNamespace': 'member_data'` option when creating a leaderboard to customize where member data is stored.
