### PR TITLE
Global memberdata

### DIFF
--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -82,6 +82,7 @@
       this.scoreKeyOption = options['scoreKey'] || 'score';
       this.memberDataKeyOption = options['memberDataKey'] || 'member_data';
       this.memberDataNamespace = options['memberDataNamespace'] || 'member_data';
+      this.useGlobalMemberData = options['useGlobalMemberData'] ? true : false;
       this.redisConnection = redisOptions['redis_connection'];
       if (this.redisConnection != null) {
         delete redisOptions['redis_connection'];
@@ -1538,7 +1539,11 @@
      */
 
     Leaderboard.prototype.memberDataKey = function(leaderboardName) {
-      return "" + leaderboardName + ":" + this.memberDataNamespace;
+      if (this.useGlobalMemberData) {
+        return "" + this.memberDataNamespace;
+      } else {
+        return "" + leaderboardName + ":" + this.memberDataNamespace;
+      }
     };
 
     return Leaderboard;

--- a/spec/leaderboard_spec.coffee
+++ b/spec/leaderboard_spec.coffee
@@ -50,7 +50,7 @@ describe 'Leaderboard', ->
       reply[0]['member_data_custom'].should.equal('member_data_25')
       done())
 
-  it.only 'should allow you to change the memberDataNamespace option', (done) ->
+  it 'should allow you to change the memberDataNamespace option', (done) ->
     updated_options =
       'memberDataNamespace': 'md'
 

--- a/spec/leaderboard_spec.coffee
+++ b/spec/leaderboard_spec.coffee
@@ -50,7 +50,7 @@ describe 'Leaderboard', ->
       reply[0]['member_data_custom'].should.equal('member_data_25')
       done())
 
-  it 'should allow you to change the memberDataNamespace option', (done) ->
+  it.only 'should allow you to change the memberDataNamespace option', (done) ->
     updated_options =
       'memberDataNamespace': 'md'
 
@@ -63,6 +63,23 @@ describe 'Leaderboard', ->
     @leaderboard.redisConnection.exists('highscores:md', (err, reply) ->
       reply.should.equal(1)
       done())
+
+    it 'should allow you to change the memberDataNamespace to global namespace', (done) ->
+      updated_options =
+        'memberDataNamespace': 'global:namespace'
+        'useGlobalMemberData': true
+
+      @leaderboard = new Leaderboard('highscores', updated_options)
+      for index in [0...Leaderboard.DEFAULT_PAGE_SIZE + 1]
+        @leaderboard.rankMember("member_#{index}", index, "member_data_#{index}", (reply) -> )
+
+      @leaderboard.redisConnection.exists('highscores:member_data', (err, reply) ->
+        reply.should.equal(0))
+      @leaderboard.redisConnection.exists('highscores:global:namespace', (err, reply) ->
+        reply.should.equal(0))
+      @leaderboard.redisConnection.exists('global:namespace', (err, reply) ->
+        reply.should.equal(1)
+        done())
 
   it 'should allow you to disconnect the Redis connection', (done) ->
     @leaderboard.disconnect()

--- a/src/leaderboard.coffee
+++ b/src/leaderboard.coffee
@@ -55,6 +55,7 @@ class Leaderboard
     @scoreKeyOption = options['scoreKey'] || 'score'
     @memberDataKeyOption = options['memberDataKey'] || 'member_data'
     @memberDataNamespace = options['memberDataNamespace'] || 'member_data'
+    @useGlobalMemberData = if (options['useGlobalMemberData']) then true else false
 
     @redisConnection = redisOptions['redis_connection']
 
@@ -1076,6 +1077,6 @@ class Leaderboard
   # @return a key in the form of +leaderboardName:member_data+
   ###
   memberDataKey: (leaderboardName) ->
-    "#{leaderboardName}:#{@memberDataNamespace}"
+    return if @useGlobalMemberData then "#{@memberDataNamespace}" else "#{leaderboardName}:#{@memberDataNamespace}"
 
 module.exports = Leaderboard


### PR DESCRIPTION
Added the option to make the memberdata independent from the leaderboard. In that case the key falls back to only `{@memberDataNamespace}`

I have not used coffeescript before, so I did it somehow in the wrong way I am happy to change it to the proper syntax.
