### PR TITLE
Memberdata allowing javascript objects

### DIFF
--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -1558,7 +1558,6 @@
 
     Leaderboard.prototype.isJsonData = function(value) {
       var e;
-      console.log(value);
       try {
         JSON.parse(str);
       } catch (_error) {

--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -328,9 +328,13 @@
      */
 
     Leaderboard.prototype.memberDataForIn = function(leaderboardName, member, callback) {
-      return this.redisConnection.hget(this.memberDataKey(leaderboardName), member, function(err, reply) {
-        return callback(reply);
-      });
+      return this.redisConnection.hget(this.memberDataKey(leaderboardName), member, (function(_this) {
+        return function(err, reply) {
+          var result;
+          result = _this.isJsonData(reply) ? JSON.parse(reply) : reply;
+          return callback(reply);
+        };
+      })(this));
     };
 
 
@@ -357,6 +361,8 @@
      */
 
     Leaderboard.prototype.updateMemberDataFor = function(leaderboardName, member, memberData, callback) {
+      var data;
+      data = typeof memberdata === 'object' ? JSON.stringify(memberData) : memberData;
       return this.redisConnection.hset(this.memberDataKey(leaderboardName), member, memberData, function(err, reply) {
         if (callback) {
           return callback(reply);
@@ -1539,6 +1545,27 @@
 
     Leaderboard.prototype.memberDataKey = function(leaderboardName) {
       return "" + leaderboardName + ":" + this.memberDataNamespace;
+    };
+
+
+    /*
+     * Checks a string if encoded json
+     *
+     * @param value [String] String to be checked.
+     *
+     * @return boolean of string is json
+     */
+
+    Leaderboard.prototype.isJsonData = function(value) {
+      var e;
+      console.log(value);
+      try {
+        JSON.parse(str);
+      } catch (_error) {
+        e = _error;
+        return false;
+      }
+      return true;
     };
 
     return Leaderboard;

--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -160,14 +160,15 @@
      */
 
     Leaderboard.prototype.rankMemberIn = function(leaderboardName, member, score, memberData, callback) {
-      var transaction;
+      var data, transaction;
       if (memberData == null) {
         memberData = null;
       }
       transaction = this.redisConnection.multi();
+      data = typeof memberData === 'object' ? JSON.stringify(memberData) : memberData;
       transaction.zadd(leaderboardName, score, member);
       if (memberData != null) {
-        transaction.hset(this.memberDataKey(leaderboardName), member, memberData);
+        transaction.hset(this.memberDataKey(leaderboardName), member, data);
       }
       return transaction.exec(function(err, reply) {
         if (callback) {
@@ -187,16 +188,17 @@
      */
 
     Leaderboard.prototype.rankMemberAcross = function(leaderboardNames, member, score, memberData, callback) {
-      var leaderboardName, transaction, _i, _len;
+      var data, leaderboardName, transaction, _i, _len;
       if (memberData == null) {
         memberData = null;
       }
+      data = typeof memberData === 'object' ? JSON.stringify(memberData) : memberData;
       transaction = this.redisConnection.multi();
       for (_i = 0, _len = leaderboardNames.length; _i < _len; _i++) {
         leaderboardName = leaderboardNames[_i];
         transaction.zadd(leaderboardName, score, member);
         if (memberData != null) {
-          transaction.hset(this.memberDataKey(leaderboardName), member, memberData);
+          transaction.hset(this.memberDataKey(leaderboardName), member, data);
         }
       }
       return transaction.exec(function(err, reply) {
@@ -332,7 +334,7 @@
         return function(err, reply) {
           var result;
           result = _this.isJsonData(reply) ? JSON.parse(reply) : reply;
-          return callback(reply);
+          return callback(result);
         };
       })(this));
     };
@@ -362,8 +364,8 @@
 
     Leaderboard.prototype.updateMemberDataFor = function(leaderboardName, member, memberData, callback) {
       var data;
-      data = typeof memberdata === 'object' ? JSON.stringify(memberData) : memberData;
-      return this.redisConnection.hset(this.memberDataKey(leaderboardName), member, memberData, function(err, reply) {
+      data = typeof memberData === 'object' ? JSON.stringify(memberData) : memberData;
+      return this.redisConnection.hset(this.memberDataKey(leaderboardName), member, data, function(err, reply) {
         if (callback) {
           return callback(reply);
         }
@@ -1559,7 +1561,7 @@
     Leaderboard.prototype.isJsonData = function(value) {
       var e;
       try {
-        JSON.parse(str);
+        JSON.parse(value);
       } catch (_error) {
         e = _error;
         return false;

--- a/spec/leaderboard_spec.coffee
+++ b/spec/leaderboard_spec.coffee
@@ -111,6 +111,17 @@ describe 'Leaderboard', ->
       reply.should.equal('Optional member data')
       done())
 
+    it 'should allow you to store and retrieve optional member data as object', (done) ->
+      data = {
+        index: 3,
+        data: 'Optional member data'
+      }
+      @leaderboard.rankMember('member', 1, data, (reply) -> )
+
+      @leaderboard.memberDataFor('member', (reply) ->
+        reply.should.equal(data)
+        done())
+
   it 'should allow you to update optional member data', (done) ->
     @leaderboard.rankMember('member', 1, 'Optional member data', (reply) -> )
 

--- a/spec/leaderboard_spec.coffee
+++ b/spec/leaderboard_spec.coffee
@@ -111,16 +111,16 @@ describe 'Leaderboard', ->
       reply.should.equal('Optional member data')
       done())
 
-    it 'should allow you to store and retrieve optional member data as object', (done) ->
-      data = {
-        index: 3,
-        data: 'Optional member data'
-      }
-      @leaderboard.rankMember('member', 1, data, (reply) -> )
+  it 'should allow you to store and retrieve optional member data as object', (done) ->
+    data = {
+      index: 3,
+      data: 'Optional member data'
+    }
+    @leaderboard.rankMember('member', 1, data, (reply) -> )
 
-      @leaderboard.memberDataFor('member', (reply) ->
-        reply.should.equal(data)
-        done())
+    @leaderboard.memberDataFor('member', (reply) ->
+      reply.should.deepEqual(data)
+      done())
 
   it 'should allow you to update optional member data', (done) ->
     @leaderboard.rankMember('member', 1, 'Optional member data', (reply) -> )

--- a/src/leaderboard.coffee
+++ b/src/leaderboard.coffee
@@ -112,8 +112,9 @@ class Leaderboard
   ###
   rankMemberIn: (leaderboardName, member, score, memberData = null, callback) ->
     transaction = @redisConnection.multi()
+    data = if typeof memberData is 'object' then JSON.stringify(memberData) else memberData
     transaction.zadd(leaderboardName, score, member)
-    transaction.hset(this.memberDataKey(leaderboardName), member, memberData) if memberData?
+    transaction.hset(this.memberDataKey(leaderboardName), member, data) if memberData?
     transaction.exec((err, reply) ->
       callback(reply) if callback)
 
@@ -126,10 +127,11 @@ class Leaderboard
   # @param member_data [String] Optional member data.
   ###
   rankMemberAcross: (leaderboardNames, member, score, memberData = null, callback) ->
+    data = if typeof memberData is 'object' then JSON.stringify(memberData) else memberData
     transaction = @redisConnection.multi()
     for leaderboardName in leaderboardNames
       transaction.zadd(leaderboardName, score, member)
-      transaction.hset(this.memberDataKey(leaderboardName), member, memberData) if memberData?
+      transaction.hset(this.memberDataKey(leaderboardName), member, data) if memberData?
     transaction.exec((err, reply) ->
       callback(reply) if callback)
 
@@ -224,7 +226,7 @@ class Leaderboard
   memberDataForIn: (leaderboardName, member, callback) ->
     @redisConnection.hget(this.memberDataKey(leaderboardName), member, (err, reply) =>
       result = if this.isJsonData(reply) then JSON.parse(reply) else reply
-      callback(reply))
+      callback(result))
 
   ###
   # Update the optional member data for a given member in the leaderboard.
@@ -245,8 +247,8 @@ class Leaderboard
   # @param callback Optional callback for result of call.
   ###
   updateMemberDataFor: (leaderboardName, member, memberData, callback) ->
-    data = if typeof memberdata is 'object' then JSON.stringify(memberData) else memberData
-    @redisConnection.hset(this.memberDataKey(leaderboardName), member, memberData, (err, reply) ->
+    data = if typeof memberData is 'object' then JSON.stringify(memberData) else memberData
+    @redisConnection.hset(this.memberDataKey(leaderboardName), member, data, (err, reply) ->
       callback(reply) if callback)
 
   ###
@@ -1089,7 +1091,7 @@ class Leaderboard
   ###
   isJsonData: (value) ->
     try
-      JSON.parse(str);
+      JSON.parse(value);
     catch e
         return false
     return true

--- a/src/leaderboard.coffee
+++ b/src/leaderboard.coffee
@@ -222,7 +222,8 @@ class Leaderboard
   # @return String of optional member data.
   ###
   memberDataForIn: (leaderboardName, member, callback) ->
-    @redisConnection.hget(this.memberDataKey(leaderboardName), member, (err, reply) ->
+    @redisConnection.hget(this.memberDataKey(leaderboardName), member, (err, reply) =>
+      result = if this.isJsonData(reply) then JSON.parse(reply) else reply
       callback(reply))
 
   ###
@@ -244,6 +245,7 @@ class Leaderboard
   # @param callback Optional callback for result of call.
   ###
   updateMemberDataFor: (leaderboardName, member, memberData, callback) ->
+    data = if typeof memberdata is 'object' then JSON.stringify(memberData) else memberData
     @redisConnection.hset(this.memberDataKey(leaderboardName), member, memberData, (err, reply) ->
       callback(reply) if callback)
 
@@ -1077,5 +1079,21 @@ class Leaderboard
   ###
   memberDataKey: (leaderboardName) ->
     "#{leaderboardName}:#{@memberDataNamespace}"
+
+  ###
+  # Checks a string if encoded json
+  #
+  # @param value [String] String to be checked.
+  #
+  # @return boolean of string is json
+  ###
+  isJsonData: (value) ->
+    try
+      JSON.parse(str);
+    catch e
+        return false
+    return true
+
+
 
 module.exports = Leaderboard


### PR DESCRIPTION
This PR allows automatic encoding and decoding of member data.

Since  some people could have implemented this manually in the Application code, I guess this PR is a BC break.
I still think it would make sense within the library, that is why I am contributing my change.
