### PR TITLE
Allow passing of url to redisOptions object

### DIFF
--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -87,7 +87,11 @@
         delete redisOptions['redis_connection'];
       }
       if (this.redisConnection == null) {
-        this.redisConnection = redis.createClient(redisOptions['port'], redisOptions['host']);
+        if(redisOptions['url']){
+          this.redisConnection = redis.createClient(redisOptions['url']);
+        } else {
+          this.redisConnection = redis.createClient(redisOptions['port'], redisOptions['host']);
+        }
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "redis"
   ],
   "dependencies": {
-    "redis": "~ 0.8",
+    "redis": "^2.6.1",
     "coffee-script": ">= 1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for adding a url parameter to the redisOptions object following the `reds://` scheme, increases compatibility with platforms like Heroku which provide `redis://` urls for connecting
