### PR TITLE
fix leadersIn not passing in leaderboardName when counting total pages

### DIFF
--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -1178,7 +1178,7 @@
         currentPage = 1;
       }
       pageSize = options['pageSize'] || this.pageSize;
-      return this.totalPages(pageSize, (function(_this) {
+      return this.totalPagesIn(leaderboardName, pageSize, (function(_this) {
         return function(totalPages) {
           var endingOffset, indexForRedis, startingOffset;
           if (currentPage > totalPages) {


### PR DESCRIPTION
leadersIn doesn't correctly find the total pages unless the constructor was passed in the same leaderboard name. This replaces the call to totalPages with totalPagesIn so the leaderboardName can be passed in
